### PR TITLE
display logo when open sub pages with smartphone

### DIFF
--- a/pycon/static/less/responsive-site.less
+++ b/pycon/static/less/responsive-site.less
@@ -42,7 +42,6 @@ body {
 		@media (max-width: @breakTablet) {
 			padding-right: 20px;
 			padding-left: 20px;
-			background-image: none;
 		}
 		// TODO削除
 		.skyline {

--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -1728,7 +1728,7 @@ header {
   margin-top: -20px;
   padding: 10px 0 20px 0;
   min-height: 155px;
-  background-image: url('../img/pagehead-bkg.png');
+  background-image: url('/2016/site_media/static/img/pagehead-bkg.png');
   background-repeat: no-repeat;
   background-position: center center;
   h1 {


### PR DESCRIPTION
スマートフォンサイズの画面で開いた時に、ロゴが出てこない報告が上がっていましたが、アレを修正しました。

スマートフォンで、トップじゃないページを表示した際にロゴが見えるハズ。
