### PR TITLE
[SAR-566]CircleCIから叩くスクリプトを本番用に変更

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ deployment:
       - sh ./deploy/deploy_staging.sh
 
   trial:
-    branch: feature/SAR-553-circleci
+    branch: SAR-566-deploy-from-circleCI
     commands:
       - sh ./deploy/deploy_trial.sh
 

--- a/deploy/deploy_production.sh
+++ b/deploy/deploy_production.sh
@@ -3,5 +3,5 @@ set -ex
 
 ssh deploy@pycon.jp uptime
 # please replace for deployment commands
-ssh deploy@pycon.jp sh -c 'date > /tmp/deploy-for-production'
+ssh deploy@pycon.jp sh /opt/workspace/deploy-scripts/update.sh production 2016
 

--- a/deploy/deploy_production.sh
+++ b/deploy/deploy_production.sh
@@ -3,5 +3,5 @@ set -ex
 
 ssh deploy@pycon.jp uptime
 # please replace for deployment commands
-ssh deploy@pycon.jp sh /opt/workspace/deploy-scripts/update.sh production 2016
+ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh production 2016
 

--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -3,5 +3,5 @@ set -ex
 
 ssh deploy@pycon.jp uptime
 # please replace for deployment commands
-ssh deploy@pycon.jp sh /opt/workspace/deploy-scripts/update.sh staging 2016
+ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh staging 2016
 

--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -3,5 +3,5 @@ set -ex
 
 ssh deploy@pycon.jp uptime
 # please replace for deployment commands
-ssh deploy@pycon.jp sh -c 'date > /tmp/deploy-for-staging'
+ssh deploy@pycon.jp sh /opt/workspace/deploy-scripts/update.sh staging 2016
 

--- a/deploy/deploy_trial.sh
+++ b/deploy/deploy_trial.sh
@@ -4,5 +4,5 @@ set -ex
 # please remove this deploy_trial.sh file after merging SAR-553-circleci branch
 
 ssh deploy@pycon.jp uptime
-ssh deploy@pycon.jp sh /opt/workspace/deploy-scripts/trial_update.sh
+ssh deploy@pycon.jp sh -u pyconjp /opt/workspace/deploy-scripts/trial_update.sh
 

--- a/deploy/deploy_trial.sh
+++ b/deploy/deploy_trial.sh
@@ -4,5 +4,5 @@ set -ex
 # please remove this deploy_trial.sh file after merging SAR-553-circleci branch
 
 ssh deploy@pycon.jp uptime
-ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/trial_update.sh
+ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh staging 2016
 

--- a/deploy/deploy_trial.sh
+++ b/deploy/deploy_trial.sh
@@ -4,5 +4,5 @@ set -ex
 # please remove this deploy_trial.sh file after merging SAR-553-circleci branch
 
 ssh deploy@pycon.jp uptime
-ssh deploy@pycon.jp sh -c 'date > /tmp/hello-from-circleci'
+ssh deploy@pycon.jp sh /opt/workspace/deploy-scripts/trial_update.sh
 

--- a/deploy/deploy_trial.sh
+++ b/deploy/deploy_trial.sh
@@ -4,5 +4,5 @@ set -ex
 # please remove this deploy_trial.sh file after merging SAR-553-circleci branch
 
 ssh deploy@pycon.jp uptime
-ssh deploy@pycon.jp sh -u pyconjp /opt/workspace/deploy-scripts/trial_update.sh
+ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/trial_update.sh
 


### PR DESCRIPTION
SAR-566: CircleCIでデプロイする

**WARNING** Pull Request は develop へ！

チケットURL
- [CircleCIでデプロイする](https://pyconjp.atlassian.net/browse/SAR-566)
### このレビューで確認してほしいこと
- [x] マージリクエストの解決で 下記コマンドが叩かれること(masterのほうは一旦コードベースですかね)
  - developブランチ: `sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh staging 2016`
  - masterブランチ: `sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh production 2016`
- [x] /opt/workspace/deploy-scripts/*.sh の内容
### 動作確認の方法
- developブランチの更新によるステージング環境の更新
  - `git checkout SAR-566-deploy-from-circleCI`
  - `git commit --allow-empty -m "テストコミット"`
  - `git push -u origin SAR-566-deploy-from-circleCI`
  - SAR-566-deploy-from-circleCIブランチはdevelopブランチ更新時と同じスクリプトを叩き、pyconjp-stg-2016がdevelopの最新になります。
- masterブランチの更新による本番環境の更新
  - `/opt/workspace/deploy-scripts/start.sh | stop.sh` を確認してください
