### PR TITLE
DockerでPyCon JP ウェブサイトを動かす

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM python:2.7.11
+
+# install lessc..
+# FIXME!! 実行環境にnodejsとlesscをインストールするのは避けたい
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g less@1.3.3
+
+# アプリの用意
+RUN mkdir -p /app; mkdir -p /var/log/pyconjp
+WORKDIR /app
+VOLUME /app
+
+COPY . /app
+RUN pip install -U pip; pip install -r /app/requirements/production.txt -f /app/wheelhouse --no-index
+
+ENV DJANGO_SETTINGS_MODULE=pyconjp.settings
+ENV ENVIRONMENT=dev
+ENV DEBUG=True
+ENV DB_ENGINE=""
+ENV DB_NAME="<YOUR_DB_NAME>"
+ENV DB_HOST=localhost
+ENV DB_PORT=
+ENV DB_USER="<YOUR_DB_USER>"
+ENV DB_PASSWORD="<YOUR_DB_PASSWORD>"
+ENV MEDIA_ROOT=
+ENV EMAIL_HOST=
+ENV EMAIL_FROM=
+ENV ALLOWED_HOSTS="localhost, 0.0.0.0"
+ENV SECRET_KEY="<YOUR_SECRET_KEY>"
+ENV LANG=ja_JP.UTF-8
+ENV TWITTER_CONSUMER_KEY="<YOUR_CONSUMER_KEY>"
+ENV TWITTER_CONSUMER_SECRET="<YOUR_CONSUMER_SECRET>"
+ENV FACEBOOK_APP_ID="<YOUR_APP_ID>"
+ENV FACEBOOK_API_SECRET="<YOUR_API_SECRET>"
+ENV LOG_PATH="/var/log/pyconjp/pyconjp_website.log"
+ENV ERROR_LOG_PATH="/var/log/pyconjp/pyconjp_website.error.log"
+ENV LOG_LEVEL="DEBUG"
+
+CMD ["bash", "/app/scripts/run-docker-website.sh"]
+

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,6 +1,48 @@
 Commands for docker
 ============================
 
+# DockerでWebアプリを開発
+
+## dbとwebを起動
+
+```
+docker-compose up -d
+```
+
+`-d` オプションでバックグラウンド実行。
+このオプションを指定しないと、フォアグラウンド実行になるので、Ctrl+C などで停止すると
+コンテナが終了する。
+
+## webだけ再起動
+
+Docker越しの開発ではファイルの変更を検知してくれないので、コード変更の適用のために手動で再起動する必要がある。
+
+```
+docker-compose restart web
+```
+
+## dbとwebを停止 & 起動
+
+```
+docker-compose stop
+docker-compose start
+```
+
+ホストOS起動時はコンテナが停止しているので、startする必要がある
+ホストOSを停止するときにはコンテナはstop状態になる。
+
+
+## dbとwebのコンテナを削除
+
+dbのデータはコンテナ内にあるので、削除するとデータが消えます。
+webのコンテナは内部にアップロードされたファイルを持っているので、削除するとデータが消えます。
+
+```
+docker-compose down
+```
+
+
+
 # 依存パッケージのwheel化
 
 このプロジェクトは、wheelhouseディレクトリに本番で利用する依存パッケージを
@@ -15,5 +57,21 @@ docker build -f Dockerfile.wheel -t pyconjp/wheelhouse:2016 .
 docker run -it --rm -v `pwd`/wheelhouse:/app/wheelhouse:ro -v `pwd`/wheelhouse_new:/app/wheelhouse_new pyconjp/wheelhouse:2016
 rm -R wheelhouse
 mv wheelhouse_new wheelhouse
+```
+
+# 細かいコマンドライン手順
+
+## pyconjp-website Dockerイメージビルド
+
+```
+docker build -t pyconjp/website:2016 .
+```
+
+## pyconjp-website コンテナ起動手順
+
+```
+docker run -it --rm -e DEBUG= -e DB_HOST=postgres -e DB_USER=postgres -e DB_PASSW
+ORD=pass -e DB_NAME=pyconjp2016 -e DB_ENGINE=postgresql_psycopg2 -e DB_PORT=5432 -p 8000:8000 --link postgres1:postgres
+pyconjp/website:2016
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,37 @@
+version: '2'
+services:
+  db:
+    image: postgres:8.4.22
+    environment:
+      POSTGRES_DB: pyconjp2016
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: pass
+    ports:
+      - "5432:5432"
+    #volumes:
+    #  - ./vol/db:/var/lib/postgresql/data
+  web:
+    build: .
+    image: pyconjp/website:2016
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    links:
+      - db:postgres
+    environment:
+      DEBUG: 1
+      ENVIRONMENT: dev
+      DB_ENGINE: postgresql_psycopg2
+      DB_NAME: pyconjp2016
+      DB_USER: postgres
+      DB_PASSWORD: pass
+      DB_HOST: postgres
+      DB_PORT: 5432
+      LOG_PATH: ./pyconjp_website.log
+      ERROR_LOG_PATH: ./pyconjp_website.error.log
+      SECRET_KEY: "<secret>"
+      LANG: ja_JP.UTF-8
+    volumes:
+      - .:/app
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
-# 開発用パッケージ
+# development packages
 -r production.txt
 
 nose==1.3.0

--- a/scripts/config-dev.sh
+++ b/scripts/config-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export DEBUG=FALSE
+export DEBUG=
 export DJANGO_SETTINGS_MODULE=pyconjp.settings
 export ENVIRONMENT=dev
 export DB_ENGINE=sqlite3

--- a/scripts/run-docker-website.sh
+++ b/scripts/run-docker-website.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ -n $DEBUG ]; then
+  LC_ALL=C pip install -r requirements/dev.txt -f wheelhouse
+fi
+
+python manage.py syncdb --noinput
+python manage.py migrate
+
+python manage.py loaddata \
+  fixtures/auth_user.json \
+  fixtures/initial_data.json \
+  fixtures/pycon.json \
+  fixtures/conference.json \
+  fixtures/initial_boxes.json \
+  fixtures/initial_data.json \
+  fixtures/proposal_base.json \
+  fixtures/sitetree_menu.json \
+  fixtures/sponsorship_benefits.json \
+  fixtures/sponsorship_levels.json \
+  fixtures/tutorials_schedule.json \
+  fixtures/talks_schedule.json \
+  fixtures/permissions.json \
+  fixtures/teams.json \
+
+echo "from django.contrib.auth.models import User; not(User.objects.filter(username='admin').exists()) and User.objects.create_superuser('admin', 'admin@example.com', 'admin')" | python manage.py shell
+
+python manage.py runserver 0.0.0.0:8000
+


### PR DESCRIPTION
使い方の手順は README-Docker.txt に書きました。

動作確認方法としては以下のように実行します。
1. docker-for-mac または docker toolbox for windows をインストールする
2. docker-machine ip でIPアドレスを確認する
3. pyconjp-website ディレクトリで `docker-compose up` を実行する
4. ブラウザで http://<手順2のIPアドレス>:8000/2016 にアクセスする
5. ID=`admin@pycon.jp`, PW=`admin` でログインする

ここまで確認しなくても、既存のファイルに悪影響を与えてなさそうならマージして欲しいな！
