### PR TITLE
remove min height on .page-content

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -410,7 +410,6 @@ aside {
 
 .page-content {
   margin-top: 20px;
-  min-height: 500px;
   .box {
     padding-right: 25px;
   }


### PR DESCRIPTION
refs SAR-355: .page-content の min-heightを削除

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-355

このレビューで確認してほしいこと
- [x] プロポーザル提出一覧画面の余分なmarginが消えている

![2016-06-04 15 15 24](https://cloud.githubusercontent.com/assets/5387939/15798068/386a2e2e-2a67-11e6-8817-ea761e13bd31.png)
