### PR TITLE
silver sponsorの表示サイズを他と合わせた

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -1109,9 +1109,6 @@ body.sponsors {
       padding: 15px 0;
       font-size: 32px;
     }
-    .container .span12:nth-child(5) .sponsor-content {
-      height: 200px;
-    }
     .sponsor {
       border: 1px solid #d2d2cb;
       .box-shadow(0 2px 2px rgba(0, 0, 0, 0.15));


### PR DESCRIPTION
refs SAR-717: 無意味に小さくなっていたシルバースポンサーの表示サイズを小さくした

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-717

このレビューで確認してほしいこと
- [ ] シルバースポンサーの枠が小さくなくなっている

![2016-06-04 15 33 45](https://cloud.githubusercontent.com/assets/5387939/15798135/bee3fa14-2a69-11e6-96d8-d6d9f4e2d6c8.png)
