### PR TITLE
SAR-723 sponsor登録すると slackのsponsorチャンネルに通知が飛ぶようにする

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -1109,9 +1109,6 @@ body.sponsors {
       padding: 15px 0;
       font-size: 32px;
     }
-    .container .span12:nth-child(5) .sponsor-content {
-      height: 200px;
-    }
     .sponsor {
       border: 1px solid #d2d2cb;
       .box-shadow(0 2px 2px rgba(0, 0, 0, 0.15));

--- a/pycon/templates/account/signup.html
+++ b/pycon/templates/account/signup.html
@@ -15,11 +15,7 @@
         <div class="span12">
             <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" class="form-horizontal"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 <legend>{% trans "Create a new account" %}</legend>
-	  <div>
-	    {% trans "Accounts on this site are for talk proposals and sponsors
-    applications. If you would like to attend PyCon JP 2016, please
-    wait until tickets go on sale in May." %}
-	  </div>
+                <div>{% trans "Accounts on this site are for talk proposals and sponsors applications. If you would like to attend PyCon JP 2016, please wait until tickets go on sale in May." %}</div>
                 <fieldset>
                     {% csrf_token %}
                     {{ form|as_bootstrap }}

--- a/pycon/templates/homepage.html
+++ b/pycon/templates/homepage.html
@@ -9,7 +9,7 @@
 {% load boxes_tags %}
 {% load pyconjp_tags %}
 
-{% block head_title_base %}PyCon JP {{ config.URL_PREFIXES }} in Tokyo | Sep 20th &ndash; Sep 23th{% endblock %}
+{% block head_title_base %}PyCon JP {{ config.URL_PREFIXES }} in Tokyo | Sep 20th &ndash; Sep 24th{% endblock %}
 
 {% block body_class %}
     {{ block.super }}
@@ -42,7 +42,7 @@
                         <ul>
                           <li><strong>Tutorials</strong> Sep. 20</li>
                           <li><strong>Conference</strong> Sep. 21&ndash;22</li>
-                          <li><strong>Sprints</strong> Sep. 23</li>
+                          <li><strong>Sprints</strong> Sep. 23&ndash;24</li>
                         </ul>
                     </div>
                     <div class="links">


### PR DESCRIPTION
refs SAR-723: <チケットタイトル or このPRの目的>

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-723

下記プルリクのコンフリクトを修正
- https://github.com/pyconjp/pyconjp-website/pull/19

このレビューで確認してほしいこと
- [x] stagingでスポンサー登録をし、 slack の#sponsorに通知が飛ぶか確認する。
