### PR TITLE
Unite some lines to one line

### DIFF
--- a/pycon/templates/account/signup.html
+++ b/pycon/templates/account/signup.html
@@ -15,11 +15,7 @@
         <div class="span12">
             <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" class="form-horizontal"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 <legend>{% trans "Create a new account" %}</legend>
-	  <div>
-	    {% trans "Accounts on this site are for talk proposals and sponsors
-    applications. If you would like to attend PyCon JP 2016, please
-    wait until tickets go on sale in May." %}
-	  </div>
+                <div>{% trans "Accounts on this site are for talk proposals and sponsors applications. If you would like to attend PyCon JP 2016, please wait until tickets go on sale in May." %}</div>
                 <fieldset>
                     {% csrf_token %}
                     {{ form|as_bootstrap }}


### PR DESCRIPTION
refs SAR-708: transタグがそのまま画面に表示されるのを修正

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-708
- https://pyconjp.atlassian.net/browse/SAR-360

このレビューで確認してほしいこと
- [x] http://HOSTNAME/2016/ja/account/signup/ の 見出し下の注意文言 $x('//*[@id="signup_form"]/div') が各言語でただしく表示されること
