### PR TITLE
SAR-858: dashboard のトークを審査した一覧にリンクを入れる

### DIFF
--- a/pycon/templates/dashboard.html
+++ b/pycon/templates/dashboard.html
@@ -283,7 +283,7 @@
                                             <td>
                                                 <b>{{ review.proposal.speaker }}</b>
                                                 <br />
-                                                <a href="{% url 'review_detail' review.pk %}">{{ review.proposal.title }}</a>
+                                                <a href="{% url 'review_detail' review.proposal.pk %}">{{ review.proposal.title }}</a>
                                             </td>
                                             <td>{{ review.vote }}</td>
                                         </tr>

--- a/pycon/templates/dashboard.html
+++ b/pycon/templates/dashboard.html
@@ -283,7 +283,7 @@
                                             <td>
                                                 <b>{{ review.proposal.speaker }}</b>
                                                 <br />
-                                                {{ review.proposal.title }}
+                                                <a href="{% url 'review_detail' review.pk %}">{{ review.proposal.title }}</a>
                                             </td>
                                             <td>{{ review.vote }}</td>
                                         </tr>


### PR DESCRIPTION
refs SAR-858: dashboard のトークを審査した一覧にリンクを入れる

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-858

このレビューで確認してほしいこと
- [ ] 各プロポーザルのタイトルがプロポーザルへリンクされていること

![image](https://cloud.githubusercontent.com/assets/35613/16382956/f7c36c50-3cbd-11e6-91ac-18a7d3a1d8e4.png)
