### PR TITLE
Change ADMINS to sympositon-group@pycon.jp

### DIFF
--- a/pyconjp/settings.py
+++ b/pyconjp/settings.py
@@ -548,8 +548,7 @@ if ENVIRONMENT == 'production':
     SECRET_KEY = os.environ["SECRET_KEY"]  # required
     ALLOWED_HOSTS = ['pycon.jp']
     ADMINS = (
-        ('Ian Lewis', 'ianmlewis@pycon.jp'),
-        ('Daisuke Komatsu', 'vkg.taro@gmail.com'),
+        ('PyConJP Symposion Group', 'symposion-group@pycon.jp'),
     )
     MANAGERS = ADMINS
 
@@ -557,8 +556,7 @@ elif ENVIRONMENT == 'staging':
     SECRET_KEY = os.environ["SECRET_KEY"]  # required
     ALLOWED_HOSTS = ['.pycon.jp']
     ADMINS = (
-        ('Ian Lewis', 'ianmlewis@pycon.jp'),
-        ('Daisuke Komatsu', 'vkg.taro@gmail.com'),
+        ('PyConJP Symposion Group', 'symposion-group@pycon.jp'),
     )
     MANAGERS = ADMINS
 


### PR DESCRIPTION
refs SAR-741: アラートメールの送信先を変更（ADMINSの変更）

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-741

このレビューで確認してほしいこと
- [ ] Djangoが送信するメールが sympositon-group@pycon.jp に届くこと(at production & staging)。
