### PR TITLE
Commented out breadcrumbs

### DIFF
--- a/pycon/templates/cms/page_detail.html
+++ b/pycon/templates/cms/page_detail.html
@@ -27,6 +27,6 @@
     {% endif %}
 {% endblock %}
 
-{% block breadcrumbs %}{% with lang=LANGUAGE_CODE|default:"en"|slice:":2" %}{% sitetree_breadcrumbs from "main-"|add:lang %}{% endwith %}{% endblock %}
+{#{% block breadcrumbs %}{% with lang=LANGUAGE_CODE|default:"en"|slice:":2" %}{% sitetree_breadcrumbs from "main-"|add:lang %}{% endwith %}{% endblock %}#}
 
 {% block body %}{# NOTE: page.subtitle is required because of django-restcms silliness. #}{% if page.subtitle %}<h1>{{ page.subtitle }}</h1>{% endif %}{{ page.body|safe }}{% endblock %}

--- a/pycon/templates/cms/page_detail.html
+++ b/pycon/templates/cms/page_detail.html
@@ -27,6 +27,4 @@
     {% endif %}
 {% endblock %}
 
-{#{% block breadcrumbs %}{% with lang=LANGUAGE_CODE|default:"en"|slice:":2" %}{% sitetree_breadcrumbs from "main-"|add:lang %}{% endwith %}{% endblock %}#}
-
 {% block body %}{# NOTE: page.subtitle is required because of django-restcms silliness. #}{% if page.subtitle %}<h1>{{ page.subtitle }}</h1>{% endif %}{{ page.body|safe }}{% endblock %}


### PR DESCRIPTION
refs SAR-739: broken link on breadcrumbs

**WARNING** Pull Request は develop へ！

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-739

このレビューで確認してほしいこと
- [ ] CMSで生成されたページでぱんくずリストが表示されないこと。

例：
http://localhost:8000/2016/ja/sponsors/prospectus/
http://localhost:8000/2016/ja/talks/cfp/
