### PR TITLE
開発環境で / にアクセスすると404エラーとなる問題を修正

### DIFF
--- a/localeurlcustom/middleware.py
+++ b/localeurlcustom/middleware.py
@@ -52,6 +52,11 @@ class LocaleURLMiddlewareCustom(object):
             ]
             if accept_langs:
                 locale = accept_langs[0]
+
+        if path == "/":
+            # If accessing root URL redirect to the URL prefix
+            return HttpResponseRedirect("/%s/" % settings.URL_PREFIXES)
+
         locale_path = utils.locale_path(path, locale)
         # locale case might be different in the two paths, that doesn't require
         # a redirect (besides locale they'll be identical anyway)


### PR DESCRIPTION
#20 の分割PRです。

チケットなし

このレビューで確認してほしいこと
- [x] dev環境で / にアクセスしたら /2016 にリダイレクトされて、最終的に /2016/ja にリダイレクトされること

本番環境では、 / にアクセスしたらnginxでリダイレクトしているので（今年は2016へ、去年は2015へ）、この修正が本番環境に影響することはないです。
