### PR TITLE
[SAR-1294] Add elements of `api/presentation/xx/`

### DIFF
--- a/pycon/apis/views.py
+++ b/pycon/apis/views.py
@@ -45,6 +45,8 @@ def api_schedule_list(request, slug=None):
 def api_presentation_detail(request, pk):
     presentation = get_object_or_404(Presentation, pk=pk)
     res = {
+        "id": presentation.pk,
+        "title": presentation.title,
         "description": presentation.description,
         "abstract": presentation.abstract,
     }


### PR DESCRIPTION
refs SAR-1294

チケットURL
- https://pyconjp.atlassian.net/browse/SAR-1294

このレビューで確認してほしいこと
- [x] `http://127.0.0.1:8000/2016/ja/api/presentation/xx/` (xxはPresentationのid)で、以下が含まれるようになること
- id (Int)
- title (String)  
- [x] 他の要素に影響がないこと
- [x] `http://127.0.0.1:8000/2016/ja/api/talks/list/` に影響がないこと 
### 元々のレスポンス

```
{
    "category": "",
    "speakers": [],
    "end": "",
    "description": "",
    "language": "",
    "level": "",
    "abstract": "",
    "start": "",
    "rooms": "",
    "day": ""
}
```
