### PR TITLE
SAR-1432 トーク詳細APIのカテゴリをローカライズ

### DIFF
--- a/pycon/apis/views.py
+++ b/pycon/apis/views.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 from django.http import HttpResponse, HttpResponseBadRequest, Http404
+from django.utils.translation import ugettext as _
 import json
 from symposion.schedule.models import Schedule, Day, Slot, Presentation
 from django.shortcuts import render, get_object_or_404
@@ -72,7 +73,7 @@ def api_presentation_detail(request, pk):
     if presentation.proposal:
         proposal = presentation.proposal
         res["level"] = proposal.get_audience_level_display().encode('utf-8')
-        res["category"] = str(proposal.category)
+        res["category"] = _(proposal.category.name)
         res["language"] = str(proposal.language)
 
     return HttpResponse(json.dumps(res), content_type="application/json")


### PR DESCRIPTION
チケットURL
- https://pyconjp.atlassian.net/browse/SAR-1432

このレビューで確認してほしいこと
- [x] APIのURLがenなら"category"が英語で表示されること /2016/ja/api/presentation/1/
- [x] APIのURLがjaなら"category"が日本語で表示されること  /2016/ja/api/presentation/1/

![image](https://cloud.githubusercontent.com/assets/151623/18409010/c1dbaa98-7779-11e6-95f6-b6f57e1dc24a.png)
