### PR TITLE
TRI-285: CircleCIから叩かれるスクリプトの2016を2017に変更する

### DIFF
--- a/deploy/deploy_production.sh
+++ b/deploy/deploy_production.sh
@@ -3,5 +3,5 @@ set -ex
 
 ssh deploy@pycon.jp uptime
 # please replace for deployment commands
-ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh production 2016
+ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh production 2017
 

--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -3,5 +3,5 @@ set -ex
 
 ssh deploy@pycon.jp uptime
 # please replace for deployment commands
-ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh staging 2016
+ssh deploy@pycon.jp sudo -u pyconjp /opt/workspace/deploy-scripts/update.sh staging 2017
 


### PR DESCRIPTION
* チケットURL
  *  https://pyconjp.atlassian.net/browse/TRI-285

このレビューで確認してほしいこと

- [x] circle.ymlで指定されたデプロイスクリプトの叩き方が2016でなく、2017になっていること
- [x] 2016と同じ叩き方で2017を起動できること
