### PR TITLE
[TRI-88] スライドやコードのリンクをスピーカー自身で登録できるようにする

### DIFF
--- a/pycon/templates/homepage.html
+++ b/pycon/templates/homepage.html
@@ -9,7 +9,7 @@
 {% load boxes_tags %}
 {% load pyconjp_tags %}
 
-{% block head_title_base %}PyCon JP {{ config.URL_PREFIXES }} in Tokyo | Sep 7th &ndash; Sep 9th{% endblock %}
+{% block head_title_base %}PyCon JP {{ config.URL_PREFIXES }} in Tokyo | Sep 7th &ndash; Sep 10th{% endblock %}
 
 {% block body_class %}
     {{ block.super }}
@@ -42,7 +42,7 @@
                         <ul>
                           <li><strong>Tutorials</strong> Sep. 7</li>
                           <li><strong>Conference</strong> Sep. 8&ndash;9</li>
-{#                          <li><strong>Sprints</strong> Sep. 23&ndash;24</li>#}
+                          <li><strong>Sprints</strong> Sep. 10</li>
                         </ul>
                     </div>
                     <div class="links">


### PR DESCRIPTION
refs TRI-88: スライドやコードのリンクをスピーカー自身で登録する仕組み

チケットURL

- https://pyconjp.atlassian.net/browse/TRI-88

このレビューで確認してほしいこと

- [ ] プロポーザルの新規登録時に動画/スライド/ソースコードのURLが記入できる
- [ ] プロポーザルの新規登録時に各種URLが保存される
- [ ] プロポーザルの表示画面でURLが表示される
- [ ] プロポーザルの変更時に各種URLが記入できる
- [ ] プロポーザルの変更時に各種URLが変更できる
- [ ] プロポーザルの変更時に各種URLが空の時にレコードが削除される


